### PR TITLE
Build things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,19 @@ python:
 sudo: false
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -r requirements.txt
+install:
+  - pip install -r requirements.txt
+  - pip install coverage
 
 # command to run tests, e.g. python setup.py test
-script: python setup.py test
+script: coverage run --source pronouncing setup.py test --verbose
+
+after_success:
+- pip install coveralls
+- coveralls # send coverage to coveralls.io
+
+after_script:
+- coverage report              # show coverage on cmd line
+- pip install pep8 pyflakes
+- pep8 --statistics --count .  # static analysis
+- pyflakes . | tee >(wc -l)    # static analysis

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ python:
   - "2.6"
   - "pypy"
 
+# Use container-based infrastructure
+sudo: false
+
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -r requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@
 language: python
 
 python:
+  - "pypy3"
+  - "pypy"
   - "3.4"
   - "3.3"
   - "3.2"
   - "2.7"
   - "2.6"
-  - "pypy3"
-  - "pypy"
 
 # Use container-based infrastructure
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ language: python
 python:
   - "3.4"
   - "3.3"
+  - "3.2"
   - "2.7"
   - "2.6"
+  - "pypy3"
   - "pypy"
 
 # Use container-based infrastructure

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py26, py27, py32, py33, py34, pypy, pypy3
 
 [testenv]
 setenv =


### PR DESCRIPTION
 * Use [container-based infrastructure](http://docs.travis-ci.com/user/workers/container-based-infrastructure/): builds will start sooner.
 * Add PyPy3 and Python 3.2: both pass with no changes.
 * Add coverage and static analysis: 100% coverage with no changes!
 * PyPy and PyPy3 builds are slower: do these build jobs first, to make best use of the (usually 5) parallel build jobs available.

TODO: enable Coveralls and badge up.