### PR TITLE
Precompile regexps before using them in a loop.

### DIFF
--- a/pronouncing/__init__.py
+++ b/pronouncing/__init__.py
@@ -19,12 +19,13 @@ def parse_cmu(cmufh):
     :returns: a list of 2-tuples pairing a word with its phones (as a string)
     """
     pronunciations = list()
+    regexp = re.compile(r'\(\d\)$')
     for line in cmufh:
         line = line.strip().decode('latin1')
         if line.startswith(';'):
             continue
         word, phones = line.split("  ")
-        word = re.sub(r'\(\d\)$', '', word.lower())
+        word = regexp.sub('', word.lower())
         pronunciations.append((word.lower(), phones))
     return pronunciations
 
@@ -167,8 +168,9 @@ def search(pattern):
     """
     init_cmu()
     matches = list()
+    regexp = re.compile(r"\b" + pattern + r"\b")
     for word, phones in pronunciations:
-        if re.search(r"\b" + pattern + r"\b", phones):
+        if regexp.search(phones):
             matches.append(word)
     return matches
 
@@ -191,8 +193,9 @@ def search_stresses(pattern):
     """
     init_cmu()
     matches = list()
+    regexp = re.compile(pattern)
     for word, phones in pronunciations:
-        if re.search(pattern, stresses(phones)):
+        if regexp.search(stresses(phones)):
             matches.append(word)
     return matches
 


### PR DESCRIPTION
Precompiling some of the regular expressions significantly speeds up initial loading of the database, `search` and `search_stresses`.

From a simple benchmark:

Function        | original time | optimized time | speedup
----------------|---------------|----------------|----------
init_cmu        | 0.5609 s      | 0.3812 s       | 1.47x
search          | 0.1849 s      | 0.0494 s       | 3.74x
search_stresses | 0.7285 s      | 0.6404 s       | 1.13x
