### PR TITLE
Replace regex with faster rstrip

### DIFF
--- a/pronouncing/__init__.py
+++ b/pronouncing/__init__.py
@@ -19,14 +19,12 @@ def parse_cmu(cmufh):
     :returns: a list of 2-tuples pairing a word with its phones (as a string)
     """
     pronunciations = list()
-    regexp = re.compile(r'\(\d\)$')
     for line in cmufh:
         line = line.strip().decode('latin1')
         if line.startswith(';'):
             continue
         word, phones = line.split("  ")
-        word = regexp.sub('', word.lower())
-        pronunciations.append((word.lower(), phones))
+        pronunciations.append((word.rstrip('(0123456789)').lower(), phones))
     return pronunciations
 
 


### PR DESCRIPTION
The big loop in `parse_cmu()` uses a regular expression to remove numbers within parentheses at the end of words.

For example:
```
REMEMBERING(1)  R IY0 M EH1 M B ER0 IH0 NG
REMEMBERING(2)  R IH0 M EH1 M B R IH0 NG
REMEMBERING(3)  R IY0 M EH1 M B R IH0 NG
```

If we can generalise a little bit and instead remove all parentheses and digits at the end, we can use the faster `rstrip` instead of a regular expression.

Here's a simple benchmark:

```
import pronouncing
for i in range(10):
    pronouncing.pronunciations = None
    pronouncing.init_cmu()
    assert(len(pronouncing.pronunciations) == 133852)
```

Before (Python 2.7, Windows 7) it took 4.534s. After, it took 3.632s, a speedup of x1.248.

Profiling with `python -m cProfile -s time bench.py` gives:

Before:

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       10    2.364    0.236    6.191    0.619 __init__.py:12(parse_cmu)
  1339100    1.098    0.000    1.098    0.000 {method 'decode' of 'str' objects}
  1338800    1.043    0.000    1.043    0.000 {method 'sub' of '_sre.SRE_Pattern' objects}
  1338520    0.640    0.000    0.640    0.000 {method 'split' of 'unicode' objects}
  2677040    0.391    0.000    0.391    0.000 {method 'lower' of 'unicode' objects}
  1339100    0.388    0.000    0.388    0.000 {method 'startswith' of 'unicode' objects}
  1339105    0.171    0.000    0.171    0.000 {method 'strip' of 'str' objects}
  1345614    0.098    0.000    0.098    0.000 {method 'append' of 'list' objects}
```

After:

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       10    2.091    0.209    4.973    0.497 __init__.py:12(parse_cmu)
  1339100    1.084    0.000    1.084    0.000 {method 'decode' of 'str' objects}
  1338520    0.614    0.000    0.614    0.000 {method 'split' of 'unicode' objects}
  1338520    0.388    0.000    0.388    0.000 {method 'rstrip' of 'unicode' objects}
  1339100    0.376    0.000    0.376    0.000 {method 'startswith' of 'unicode' objects}
  1338520    0.171    0.000    0.171    0.000 {method 'lower' of 'unicode' objects}
  1339105    0.159    0.000    0.159    0.000 {method 'strip' of 'str' objects}
  1345588    0.089    0.000    0.089    0.000 {method 'append' of 'list' objects}
```

Notably,
```
  1338800    1.043    0.000    1.043    0.000 {method 'sub' of '_sre.SRE_Pattern' objects}
```
is replaced by
```
  1338520    0.388    0.000    0.388    0.000 {method 'rstrip' of 'unicode' objects}
```

---

I think this generalisation is safe given the data. If not, something like `rstrip(")").rstrip("01234567890").rstrip("(")` might also be faster than the regex.
