### PR TITLE
Faster phones

### DIFF
--- a/pronouncing/__init__.py
+++ b/pronouncing/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import re
 from pkg_resources import resource_stream
+import collections
 
 __author__ = 'Allison Parrish'
 __email__ = 'allison@decontextualize.com'
@@ -18,13 +19,13 @@ def parse_cmu(cmufh):
     :param cmufh: a filehandle with CMUdict-formatted data
     :returns: a list of 2-tuples pairing a word with its phones (as a string)
     """
-    pronunciations = list()
+    pronunciations = collections.defaultdict(list)
     for line in cmufh:
         line = line.strip().decode('latin1')
         if line.startswith(';'):
             continue
         word, phones = line.split("  ")
-        pronunciations.append((word.rstrip('(0123456789)').lower(), phones))
+        pronunciations[word.rstrip('(0123456789)').lower()].append(phones)
     return pronunciations
 
 
@@ -83,9 +84,7 @@ def phones_for_word(find):
     :returns: a list of phone strings that correspond to that word.
     """
     init_cmu()
-    return [phones
-            for word, phones in pronunciations
-            if word == find]
+    return pronunciations.get(find, [])
 
 
 def stresses(s):
@@ -162,9 +161,12 @@ def search(pattern):
     """
     init_cmu()
     regexp = re.compile(r"\b" + pattern + r"\b")
-    return [word
-            for word, phones in pronunciations
-            if regexp.search(phones)]
+    result = set()
+    for word, phones_list in pronunciations.iteritems():
+        for phones in phones_list:
+            if regexp.search(phones):
+                result.add(word)
+    return result
 
 
 def search_stresses(pattern):
@@ -185,9 +187,12 @@ def search_stresses(pattern):
     """
     init_cmu()
     regexp = re.compile(pattern)
-    return [word
-            for word, phones in pronunciations
-            if regexp.search(stresses(phones))]
+    result = set()
+    for word, phones_list in pronunciations.iteritems():
+        for phones in phones_list:
+            if regexp.search(stresses(phones)):
+                result.add(word)
+    return result
 
 
 def rhymes(word):
@@ -211,4 +216,4 @@ def rhymes(word):
         part = rhyming_part(phones_str)
         rhymes = search(part + "$")
         all_rhymes.extend(rhymes)
-    return [r for r in all_rhymes if r != word]
+    return set(r for r in all_rhymes if r != word)

--- a/pronouncing/__init__.py
+++ b/pronouncing/__init__.py
@@ -162,7 +162,7 @@ def search(pattern):
     init_cmu()
     regexp = re.compile(r"\b" + pattern + r"\b")
     result = set()
-    for word, phones_list in pronunciations.iteritems():
+    for word, phones_list in pronunciations.items():
         for phones in phones_list:
             if regexp.search(phones):
                 result.add(word)
@@ -188,7 +188,7 @@ def search_stresses(pattern):
     init_cmu()
     regexp = re.compile(pattern)
     result = set()
-    for word, phones_list in pronunciations.iteritems():
+    for word, phones_list in pronunciations.items():
         for phones in phones_list:
             if regexp.search(stresses(phones)):
                 result.add(word)

--- a/tests/test_pronouncing.py
+++ b/tests/test_pronouncing.py
@@ -13,7 +13,7 @@ ADOLESCENT(1)  AE2 D OW0 L EH1 S AH0 N T
         cmufh = io.BytesIO(test_str)
         pronunciations = pronouncing.parse_cmu(cmufh)
         self.assertTrue(len(pronunciations) > 0)
-        matches = [x for x in pronunciations if x[0] == 'adolescent']
+        matches = pronunciations.get('adolescent')
         self.assertEqual(len(matches), 2)
 
     def test_syllable_count(self):
@@ -40,20 +40,20 @@ ADOLESCENT(1)  AE2 D OW0 L EH1 S AH0 N T
     def test_search(self):
         matches = pronouncing.search('^S K L')
         self.assertEqual(matches,
-                         ['sclafani', 'scleroderma', 'sclerosis', 'sklar',
-                             'sklenar'])
+                         set(['sclafani', 'scleroderma', 'sclerosis', 'sklar',
+                              'sklenar']))
         matches = pronouncing.search('IH. \w* IH. \w* IH. \w* IH.')
         self.assertEqual(matches,
-                         ['definitive', 'definitively', 'diminishes',
-                             'diminishing', 'elicited', 'miscibility',
-                             'primitivistic', 'privileges'])
+                         set(['definitive', 'definitively', 'diminishes',
+                              'diminishing', 'elicited', 'miscibility',
+                              'primitivistic', 'privileges']))
 
     def test_rhymes(self):
         rhymes = pronouncing.rhymes("sleekly")
-        expected = [
+        expected = set([
             'beakley', 'biweekly', 'bleakley', 'meekly', 'obliquely',
             'steakley', 'szekely', 'uniquely', 'weakley', 'weakly',
-            'weekley', 'weekly', 'yeakley']
+            'weekley', 'weekly', 'yeakley'])
         self.assertEqual(expected, rhymes)
 
     def test_stresses(self):
@@ -70,12 +70,12 @@ ADOLESCENT(1)  AE2 D OW0 L EH1 S AH0 N T
         words = pronouncing.search_stresses('^000100$')
         self.assertEqual(
             words,
-            ['phytogeography', 'uninterruptible', 'uninterruptible',
-                'variability'])
+            set(['phytogeography', 'uninterruptible', 'uninterruptible',
+                 'variability']))
         words = pronouncing.search_stresses('^[12]0[12]0[12]0[12]$')
         self.assertEqual(
             words,
-            ['dideoxycytidine', 'homosexuality', 'hypersensitivity'])
+            set(['dideoxycytidine', 'homosexuality', 'hypersensitivity']))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Changed to the `pronunciations` list to a dictionary to make the lookup in `phones_for_word` faster. For example, getting the phones for Shakespeare's sonnets with:
```python
import pycorpora
import pronouncing
data = pycorpora.words.literature.shakespeare_sonnets
for sonnet in data['sonnets']:
    for line in sonnet['lines']:
        for word in line.split():
            pronouncing.phones_for_word(word)
```
takes ~1/2 second instead of ~3 minutes on my laptop.

Since the dictionary isn't iterated over in the same order as the list, I also switched the methods that return lists (like `rhymes`) to sets so that the tests pass.