### PR TITLE
Replace 'open' with a portable command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ coverage:
 	coverage run --source pronouncing setup.py test
 	coverage report -m
 	coverage html
-	open htmlcov/index.html
+	python -m webbrowser htmlcov/index.html
 
 docs:
 	rm -f docs/pronouncingpy.rst
@@ -55,7 +55,7 @@ docs:
 	sphinx-apidoc -o docs/ pronouncing
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
-	open docs/_build/html/index.html
+	python -m webbrowser docs/_build/html/index.html
 
 release: clean
 	python setup.py sdist upload


### PR DESCRIPTION
'open' is only available on Mac, which made 'coverage' and 'docs' fail on Linux.
Since we already depend on Python, we can use the `webbrowser` module.