### PR TITLE
Test uncovered return of rhyming_part()

### DIFF
--- a/tests/test_pronouncing.py
+++ b/tests/test_pronouncing.py
@@ -36,6 +36,8 @@ ADOLESCENT(1)  AE2 D OW0 L EH1 S AH0 N T
         self.assertEqual(part, "IY1 P ER0")
         part = pronouncing.rhyming_part("S L IY1 P AH0 L IY0")
         self.assertEqual(part, "IY1 P AH0 L IY0")
+        part = pronouncing.rhyming_part("M ER0 M AE0 N S K")
+        self.assertEqual(part, "M ER0 M AE0 N S K")
 
     def test_search(self):
         matches = pronouncing.search('^S K L')


### PR DESCRIPTION
The last line of `rhyming_part` (refactored in https://github.com/aparrish/pronouncingpy/commit/452aca8e26d914389d067abad41755a9ee64ee24 from PR #4) isn't covered by tests.

```python
def rhyming_part(phones):
    """Get the "rhyming part" of a string with CMUdict phones.

    "Rhyming part" here means everything from the vowel in the stressed
    syllable nearest the end of the word up to the end of the word.

    .. doctest::

        >>> import pronouncing
        >>> phones = pronouncing.phones_for_word("purple")
        >>> pronouncing.rhyming_part(phones)
        u'ER1 P AH0 L'

    :param phones: a string containing space-separated CMUdict phones
    :returns: a string with just the "rhyming part" of those phones
    """
    phones_list = phones.split()
    for i in range(len(phones_list) - 1, 0, -1):
        if phones_list[i][-1] in '12':
            return ' '.join(phones_list[i:])
    return phones
```

This is the case where CMUdict phone entries don't contain a zero or one, for example:
```txt
MCKREE  M AH0 K R IY0
MHM  AH0 M HH AH0 M
MURMANSK  M ER0 M AE0 N S K
NUSBAUM  N AH0 S B AW0 M
```

So let's test that. And coverage is back to 100%!