### PR TITLE
Dict lookup

### DIFF
--- a/pronouncing/__init__.py
+++ b/pronouncing/__init__.py
@@ -1,12 +1,14 @@
 from __future__ import print_function
 import re
 from pkg_resources import resource_stream
+import collections
 
 __author__ = 'Allison Parrish'
 __email__ = 'allison@decontextualize.com'
 __version__ = '0.1.2'
 
 pronunciations = None
+lookup = None
 
 
 def parse_cmu(cmufh):
@@ -40,12 +42,15 @@ def init_cmu(filehandle=None):
     :param filehandle: a filehandle with CMUdict-formatted data
     :returns: None
     """
-    global pronunciations
+    global pronunciations, lookup
     if pronunciations is None:
         if filehandle is None:
             filehandle = resource_stream(__name__, 'cmudict-0.7b')
         pronunciations = parse_cmu(filehandle)
         filehandle.close()
+        lookup = collections.defaultdict(list)
+        for word, phones in pronunciations:
+            lookup[word].append(phones)
 
 
 def syllable_count(phones):
@@ -83,9 +88,7 @@ def phones_for_word(find):
     :returns: a list of phone strings that correspond to that word.
     """
     init_cmu()
-    return [phones
-            for word, phones in pronunciations
-            if word == find]
+    return lookup.get(find, [])
 
 
 def stresses(s):

--- a/tests/test_pronouncing.py
+++ b/tests/test_pronouncing.py
@@ -30,6 +30,9 @@ ADOLESCENT(1)  AE2 D OW0 L EH1 S AH0 N T
         phones = pronouncing.phones_for_word("conflicts")
         self.assertEqual(len(phones), 4)
         self.assertEqual(phones[0], "K AH0 N F L IH1 K T S")
+        # not in the dictionary (presumably)
+        phones = pronouncing.phones_for_word("asdfasdfasdf")
+        self.assertEqual(phones, [])
 
     def test_rhyming_part(self):
         part = pronouncing.rhyming_part("S L IY1 P ER0")


### PR DESCRIPTION
Okay, I finally caved (see #8, #10) after like the fifth time that I pip-installed my own module and was surprised by its behavior. This PR adds a dictionary lookup for words, alongside the existing list. This compromise uses a bit more memory (~30mb) but that the functions relying on `search()` don't suffer any slowdown and that the results from `.search()` are still returned in alphabetical order. The `phones_for_word()` function is, of course, much much faster.