### PR TITLE
Fix rhyming_part docstring

### DIFF
--- a/pronouncing/__init__.py
+++ b/pronouncing/__init__.py
@@ -134,7 +134,7 @@ def rhyming_part(phones):
 
         >>> import pronouncing
         >>> phones = pronouncing.phones_for_word("purple")
-        >>> pronouncing.rhyming_part(phones)
+        >>> pronouncing.rhyming_part(phones[0])
         u'ER1 P AH0 L'
 
     :param phones: a string containing space-separated CMUdict phones


### PR DESCRIPTION
Fixes #24.

* `phones_for_word("purple")` returns a list: `[u'P ER1 P AH0 L']`

* `rhyming_part` expects a string parameter, e.g. `'P ER1 P AH0 L'`