### PR TITLE
Fix syllable_count docstring

### DIFF
--- a/pronouncing/__init__.py
+++ b/pronouncing/__init__.py
@@ -63,7 +63,7 @@ def syllable_count(phones):
 
         >>> import pronouncing
         >>> phones = pronouncing.phones_for_word("literally")
-        >>> pronouncing.syllable_count(phones)
+        >>> pronouncing.syllable_count(phones[0])
         4
 
     :param phones: a string containing space-separated CMUdict phones


### PR DESCRIPTION
Fixes #26.

* `phones_for_word("literally")` returns a list: `[u'L IH1 T ER0 AH0 L IY0', u'L IH1 T R AH0 L IY0']`

* `syllable_count` expects a string parameter, e.g. `'L IH1 T ER0 AH0 L IY0'`