### PR TITLE
Run doctest on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ install:
   - pip install coverage
 
 # command to run tests, e.g. python setup.py test
-script: coverage run --source pronouncing setup.py test --verbose
+script:
+  - coverage run --source pronouncing setup.py test --verbose
+  - python -m doctest -v pronouncing/__init__.py
 
 after_success:
 - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
 # command to run tests, e.g. python setup.py test
 script:
   - coverage run --source pronouncing setup.py test --verbose
-  - python -m doctest -v pronouncing/__init__.py
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then python -m doctest pronouncing/__init__.py; fi
 
 after_success:
 - pip install coveralls

--- a/pronouncing/__init__.py
+++ b/pronouncing/__init__.py
@@ -88,7 +88,7 @@ def phones_for_word(find):
 
         >>> import pronouncing
         >>> pronouncing.phones_for_word("permit")
-        [u'P ER0 M IH1 T', u'P ER1 M IH2 T']
+        ['P ER0 M IH1 T', 'P ER1 M IH2 T']
 
     :param find: a word to find in CMUdict.
     :returns: a list of phone strings that correspond to that word.
@@ -106,7 +106,7 @@ def stresses(s):
 
         >>> import pronouncing
         >>> pronouncing.stresses(pronouncing.phones_for_word('obsequious')[0])
-        u'0100'
+        '0100'
 
     :param s: a string of CMUdict phones
     :returns: string of just the stresses
@@ -121,7 +121,7 @@ def stresses_for_word(find):
 
         >>> import pronouncing
         >>> pronouncing.stresses_for_word('permit')
-        [u'01', u'12']
+        ['01', '12']
 
     :param find: a word to find
     :returns: a list of possible stress patterns for the given word.
@@ -141,7 +141,7 @@ def rhyming_part(phones):
         >>> import pronouncing
         >>> phones = pronouncing.phones_for_word("purple")
         >>> pronouncing.rhyming_part(phones[0])
-        u'ER1 P AH0 L'
+        'ER1 P AH0 L'
 
     :param phones: a string containing space-separated CMUdict phones
     :returns: a string with just the "rhyming part" of those phones
@@ -163,7 +163,7 @@ def search(pattern):
     .. doctest::
 
         >>> import pronouncing
-        >>> u'interpolate' in pronouncing.search('ER1 P AH0')
+        >>> 'interpolate' in pronouncing.search('ER1 P AH0')
         True
 
     :param pattern: a string containing a regular expression
@@ -187,7 +187,7 @@ def search_stresses(pattern):
 
         >>> import pronouncing
         >>> pronouncing.search_stresses('020120')
-        [u'gubernatorial']
+        ['gubernatorial']
 
     :param pattern: a string containing a regular expression
     :returns: a list of matching words
@@ -210,7 +210,7 @@ def rhymes(word):
 
         >>> import pronouncing
         >>> pronouncing.rhymes("conditioner")
-        [u'commissioner', u'parishioner', u'petitioner', u'practitioner']
+        ['commissioner', 'parishioner', 'petitioner', 'practitioner']
 
     :param word: a word
     :returns: a list of rhyming words

--- a/pronouncing/__init__.py
+++ b/pronouncing/__init__.py
@@ -163,8 +163,8 @@ def search(pattern):
     .. doctest::
 
         >>> import pronouncing
-        >>> pronouncing.search('ER1 P AH0')
-        [u'interpolate', u'interpolated', u'purple', u'purples']
+        >>> u'interpolate' in pronouncing.search('ER1 P AH0')
+        True
 
     :param pattern: a string containing a regular expression
     :returns: a list of matching words


### PR DESCRIPTION
Fixes #24.

It's tricky to run doctests with the `u` Unicode prefix on Python 2 and 3, so just run them for Python 3 for more coverage, because Python 3 is the way forward, and because Pronouncing is used more on Python 3.

Here's the pip installs for Pronouncing from PyPI for last month:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 3.6            |  54.17% |            104 |
| 2.7            |  31.25% |             60 |
| 3.5            |  11.46% |             22 |
| 3.4            |   2.60% |              5 |
| 3.7            |   0.52% |              1 |

Source: `pypinfo --start-date -39 --end-date -9 --percent --pip --markdown pronouncing pyversion`