### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,17 @@
 
 language: python
 
-python:
-  - "pypy3"
-  - "pypy"
-  - "3.6"
-  - "3.5"
-  - "3.4"
-  - "2.7"
+matrix:
+  include:
+    - python: "pypy3"
+    - python: "pypy"
+    - python: "3.7"
+      dist: xenial
+      sudo: true
+    - python: "3.6"
+    - python: "3.5"
+    - python: "3.4"
+    - python: "2.7"
 
 # Use container-based infrastructure
 sudo: false

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         "Intended Audience :: Developers",
         "Intended Audience :: Education",
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
Python 3.7 is out, and needs a little workaround for Travis CI, see https://github.com/travis-ci/travis-ci/issues/9815 for more info.