### PR TITLE
Version restriction on cmudict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 requirements = [
-    'cmudict>=0.4.0'
+    'cmudict>=0.4.0,<=1.0.2'
 ]
 
 test_requirements = [


### PR DESCRIPTION
Hi,  I noticed [this](https://github.com/prosegrinder/python-cmudict/issues/32) which makes me think that new versions of `cmudict` have broken `pronouncing`.  I noticed that my problems go away if I explicitly install cmudict like:

```Dockerfile
pip install cmudict==1.0.2
```

So I think it's likely that other users of your library would also benefit from this version restriction.  That said, I haven't actually tested the change that I'm proposing here, it's just a hunch.