### PR TITLE
Remove unused and deprecated import

### DIFF
--- a/pronouncing/__init__.py
+++ b/pronouncing/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 from itertools import chain
 import re
-from pkg_resources import resource_stream
 import collections
 import cmudict
 


### PR DESCRIPTION
Fixes #64.

The `from pkg_resources import resource_stream` isn't used, and is causing deprecation warnings.

Let's remove it.